### PR TITLE
Ping neighbours in loop

### DIFF
--- a/src/braidnode_connector.erl
+++ b/src/braidnode_connector.erl
@@ -40,7 +40,17 @@ handle_info(_Request, State) ->
     {noreply, State}.
 
 ping_nodes(Connections) ->
-    lists:foreach(fun(Node) ->
-        ?LOG_NOTICE("~p pings ~p: ~p~n", [node(), Node, net_adm:ping(Node)])
+    lists:foreach(fun(Node) -> 
+        spawn(fun() -> ping_loop(Node) end)
     end, Connections),
     ?LOG_NOTICE("Names: ~p~n", [net_adm:names()]).
+
+ping_loop(Node) ->
+    Result =  net_adm:ping(Node),
+    ?LOG_NOTICE("~p pings ~p: ~p~n", [node(), Node, Result]),
+    case Result of
+        ping -> ok;
+        pang -> 
+            timer:sleep(1000),
+            ping_loop(Node)
+    end.


### PR DESCRIPTION
There is the chance that during boot one node and all the neighbors attempt ping before distribution is setup. 
As a quick fix, the neighbors are pinged in a loop until success.