### PR TITLE
Move to OTP 27

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -1,7 +1,7 @@
 [
     {braidnode,[
         {braidnet_domain, "localhost"},
-        {braidnet_port, 8080}
+        {braidnet_port, 9090}
     ]},
     {kernel, [
         {connect_all, false}, % very important to avoid transitive connections

--- a/config/vm.args.src
+++ b/config/vm.args.src
@@ -2,4 +2,4 @@
 -setcookie cookie
 -proto_dist inet6_tls
 -epmd_module braidnode_epmd
--ssl_dist_optfile "/opt/braidnode/lib/braidnode-0.1.0/priv/ssl_dist_opts.rel"
+-ssl_dist_optfile "/opt/braidnode/lib/braidnode-0.2.0/priv/ssl_dist_opts.rel"

--- a/priv/ssl_dist_opts.rel
+++ b/priv/ssl_dist_opts.rel
@@ -2,6 +2,7 @@
     {server, [
         {cacertfile, "/mnt/certs/braidcert.CA.pem"},
         {verify, verify_peer},
+        {fail_if_no_peer_cert, true},
         {certs_keys, [
             #{certfile =>  "/mnt/certs/braidnode.pem",
               key => #{algorithm => rsa,

--- a/priv/ssl_dist_opts.rel
+++ b/priv/ssl_dist_opts.rel
@@ -1,20 +1,22 @@
 [
     {server, [
         {cacertfile, "/mnt/certs/braidcert.CA.pem"},
-        {certfile, "/mnt/certs/braidnode.pem"},
         {verify, verify_peer},
-        {key, #{
-            algorithm => rsa,
-            sign_fun => {braidnode_crypto, sign_fun}
-        }}
+        {certs_keys, [
+            #{certfile =>  "/mnt/certs/braidnode.pem",
+              key => #{algorithm => rsa,
+                       sign_fun => fun braidnode_crypto:sign_fun/3}
+            }
+        ]}
     ]},
     {client, [
-        {cacertfile, "/mnt/certs/braidcert.CA.pem"},
-        {certfile, "/mnt/certs/braidnode.pem"},
+        {cacertfile, "/mnt/certs/braidcert.CA.pem"},=
         {verify, verify_peer},
-        {key, #{
-            algorithm => rsa,
-            sign_fun => {braidnode_crypto, sign_fun}
-        }}
+        {certs_keys, [
+            #{certfile =>  "/mnt/certs/braidnode.pem",
+              key => #{algorithm => rsa,
+                       sign_fun => fun braidnode_crypto:sign_fun/3}
+            }
+        ]}
     ]}
 ].

--- a/priv/ssl_dist_opts.rel
+++ b/priv/ssl_dist_opts.rel
@@ -10,7 +10,7 @@
         ]}
     ]},
     {client, [
-        {cacertfile, "/mnt/certs/braidcert.CA.pem"},=
+        {cacertfile, "/mnt/certs/braidcert.CA.pem"},
         {verify, verify_peer},
         {certs_keys, [
             #{certfile =>  "/mnt/certs/braidnode.pem",

--- a/priv/templates/braidnode_app/config/ssl_dist_opts.rel
+++ b/priv/templates/braidnode_app/config/ssl_dist_opts.rel
@@ -1,20 +1,22 @@
 [
     {server, [
         {cacertfile, "/mnt/certs/braidcert.CA.pem"},
-        {certfile, "/mnt/certs/braidnode.pem"},
         {verify, verify_peer},
-        {key, #{
-            algorithm => rsa,
-            sign_fun => {braidnode_crypto, sign_fun}
-        }}
+        {certs_keys, [
+            #{certfile =>  "/mnt/certs/braidnode.pem",
+              key => #{algorithm => rsa,
+                       sign_fun => fun braidnode_crypto:sign_fun/3}
+            }
+        ]}
     ]},
     {client, [
         {cacertfile, "/mnt/certs/braidcert.CA.pem"},
-        {certfile, "/mnt/certs/braidnode.pem"},
         {verify, verify_peer},
-        {key, #{
-            algorithm => rsa,
-            sign_fun => {braidnode_crypto, sign_fun}
-        }}
+        {certs_keys, [
+            #{certfile =>  "/mnt/certs/braidnode.pem",
+              key => #{algorithm => rsa,
+                       sign_fun => fun braidnode_crypto:sign_fun/3}
+            }
+        ]}
     ]}
 ].

--- a/priv/templates/braidnode_app/config/sys.config
+++ b/priv/templates/braidnode_app/config/sys.config
@@ -1,7 +1,7 @@
 [
     {braidnode,[
         {braidnet_domain, "localhost"},
-        {braidnet_port, 8080}
+        {braidnet_port, 9090}
     ]},
     {kernel, [
         {connect_all, false},

--- a/rebar.config
+++ b/rebar.config
@@ -17,7 +17,7 @@
 ]}.
 
 {relx, [
-    {release, {braidnode, "0.1.0"}, [sasl, braidnode]},
+    {release, {braidnode, "0.2.0"}, [sasl, braidnode]},
     {sys_config, "config/sys.config"},
     {include_src, false},
     {include_erts, true}

--- a/rebar.config
+++ b/rebar.config
@@ -25,7 +25,7 @@
 
 {docker, [
   % builder_image image has precedence over erlang_version
-  {builder_image, "grisp/extended_ssl_erlang"},
+  {builder_image, "erlang:27-alpine"},
   {tag, "local/braidnode"},
   % The extra packages to install in the building docker layer.
   {build_packages, [

--- a/src/braidnode.app.src
+++ b/src/braidnode.app.src
@@ -1,6 +1,6 @@
 {application, braidnode,
  [{description, "Otp App to connect to a braidnet orchestrator"},
-  {vsn, "0.1.0"},
+  {vsn, "0.2.0"},
   {registered, []},
   {mod, {braidnode_app, []}},
   {applications,

--- a/src/braidnode_connector.erl
+++ b/src/braidnode_connector.erl
@@ -29,8 +29,14 @@ handle_call(_Request, _From, State) ->
     {reply, ok, State}.
 
 handle_cast(add_node_to_cluster, State) ->
-    {ok, Connections} = braidnode_epmd:register_with_braidnet(),
-    ping_nodes(Connections),
+    case whereis(braidnode_epmd) of
+       undefined ->
+            ?LOG_WARNING("Could not register braidnode to epmd, "
+                         "braidnode_epmd is not running!");
+       _ ->
+            {ok, Connections} = braidnode_epmd:register_with_braidnet(),
+            ping_nodes(Connections)
+    end,
     {noreply, State};
 
 handle_cast(_Request, State) ->

--- a/src/braidnode_crypto.erl
+++ b/src/braidnode_crypto.erl
@@ -1,12 +1,12 @@
 -module(braidnode_crypto).
 
--export([sign_fun/5]).
+-export([sign_fun/3]).
 
-sign_fun(_Version, Msg, HashAlg, _Key, SignAlg) ->
+sign_fun(Msg, DigestType, _Opts) ->
     Result = braidnode_client:send_receive(sign, #{
         payload => base64:encode(erlang:term_to_binary(Msg)),
-        hash_alg => HashAlg,
-        sign_alg => SignAlg
+        hash_alg => DigestType,
+        sign_alg => rsa
     }),
     case Result of
         Signature when is_binary(Signature) ->

--- a/src/braidnode_crypto.erl
+++ b/src/braidnode_crypto.erl
@@ -2,11 +2,11 @@
 
 -export([sign_fun/3]).
 
-sign_fun(Msg, DigestType, _Opts) ->
+sign_fun(Msg, DigestType, Options) ->
     Result = braidnode_client:send_receive(sign, #{
         payload => base64:encode(erlang:term_to_binary(Msg)),
         hash_alg => DigestType,
-        sign_alg => rsa
+        sign_options => maps:from_list(Options)
     }),
     case Result of
         Signature when is_binary(Signature) ->


### PR DESCRIPTION
- ssl dist opts in OTP 27 format
- changed braidnet API port
- Use TLS in internal connection to braidnet
- Updated templates for rebar3 apps
- Version 0.2.0