### PR TITLE
Support multiple device types (Platforms)

### DIFF
--- a/config/vm.args.src
+++ b/config/vm.args.src
@@ -2,4 +2,4 @@
 -setcookie cookie
 -proto_dist inet6_tls
 -epmd_module braidnode_epmd
--ssl_dist_optfile "/opt/braidnode/lib/braidnode-0.2.0/priv/ssl_dist_opts.rel"
+-ssl_dist_optfile "/opt/braidnode/lib/braidnode-1.0.1/priv/ssl_dist_opts.rel"

--- a/src/braidnode_crypto.erl
+++ b/src/braidnode_crypto.erl
@@ -6,7 +6,7 @@
 -include_lib("public_key/include/public_key.hrl").
 
 -define(DEVICE_SERIAL_NUMBERS, "DEVICE_SERIAL_NUMBERS").
--define(ALWAYS_ALLOWED_NAMES, [<<"GRiSP2 CA">>]).
+-define(ALWAYS_ALLOWED_NAMES, [<<"GRiSP2 CA">>, <<"devices.seawater.local">>]).
 
 sign_fun(Msg, DigestType, Options) ->
     Result = braidnode_client:send_receive(sign, #{
@@ -52,7 +52,9 @@ verify_subject(DeviceSerials, OtpCert, State) ->
     end.
 
 gen_board_common_names(DeviceSerials) ->
-    [list_to_binary("GRiSP2 device " ++ N) || N <- string:split(DeviceSerials, ";", all)].
+    [list_to_binary("GRiSP2 device " ++ N) || N <- string:split(DeviceSerials, ";", all)]
+    ++
+    [list_to_binary("generic device " ++ N) || N <- string:split(DeviceSerials, ";", all)].
 
 get_common_name(OtpCert) ->
     Sub = OtpCert#'OTPCertificate'.tbsCertificate#'OTPTBSCertificate'.subject,


### PR DESCRIPTION
We need to be able to support different devices that are not just grisp boards.

A new OS env variable `DEVICE_IDENTIFIERS` is expected.
This contains a list of device IDs in the form platform-serial, like: `generi-0001;generic-0002`

Devices that connect are expected to provide the common name field in their certificate like:
`"{PLATFORM} device {SERIAL}"`

If this variable is defined, only peers that are in this list will be accepted.
If empty, the list is ignored and any certificate from the braidcert CA is accepted.


The CA `devices.seawater.local `is a temporary addition for development purposes.

